### PR TITLE
Add encrypted sonatype file and tell Travis to decrypt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ jdk:
   - oraclejdk8
 
 before_script:
+  - openssl aes-256-cbc -K $encrypted_913079356b93_key -iv $encrypted_913079356b93_iv -in sonatype.sbt.enc -out sonatype.sbt -d
   # default $SBT_OPTS is irrelevant to sbt launcher
   - unset SBT_OPTS
   - chmod +x ./bin/build

--- a/sonatype.sbt.enc
+++ b/sonatype.sbt.enc
@@ -1,0 +1,2 @@
+øs´ÜX²ž¢Ys%Ðkj ¤™-I‘H¹jØå–‘¿j¸{¶ŸA–?n
+V)N¨wô÷¥°ZÈp(Rn±/1aVªÛejíÚô%ÎÿUªFL¤c#Ýã	Ÿa{lâÂ÷dØÖç‰f4£V&à0%ÔÆ¹nõ¦O˜fV÷ßoá pgisãµßC9¸Ò\t@2MdôVŸt°g$JMÝæe&’ê|,¿ÅØ9…W]†LFš³Ûªhêˆ”Æ´y¤


### PR DESCRIPTION
Problem

The sbt publish plugin requires the sonatype.sbt file to exist on Travis. 

Solution

Add the encrypted file to dodo and tell Travis to decrypt it.