### PR TITLE
dodo: update travis config to use trust dist, update scala/jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: scala
-dist: trusty
 
 scala:
   - 2.11.12


### PR DESCRIPTION
Problem

The dodo `.travis.yml` configuration is using the default travis
build image, which has been moved to `dist: xenial` and does
not have the `oraclejdk8` available.

Solution

Explicitly list `dist: trusty`, as the other Twitter ecosystem projects
do. Modify the Scala version to match our other projects. Add
support for jdk11.

Result

Dodo build should pass.
