### PR TITLE
dodo: specify trusty dist in travis, update jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: scala
+dist: trusty
 
 scala:
-  - 2.11.8
+  - 2.11.12
+  - 2.12.8
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk11
 
 before_script:
   # See https://docs.travis-ci.com/user/encrypting-files/#automated-encryption


### PR DESCRIPTION
Problem

The dodo .travis.yml configuration is using the default travis
build image, which has been moved to `dist: xenial` and does
not have the oraclejdk8 available.

Solution

Explicitly list `dist: trusty`, as the other Twitter ecosystem projects
do. Modify the Scala version to match our other projects. Move to
openjdk and add support for jdk11.

Result

Dodo build should pass.