### PR TITLE
dodo: update build script to use JDK11 friendly sbt and scala versions

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -14,7 +14,7 @@ UTIL_COMMANDS="./sbt +test:compile +publishLocal; ./sbt ++2.11.12 util-intellij/
 declare "util_name=util"
 declare "util_commands=$UTIL_COMMANDS"
 
-SCROOGE_CORE_COMMANDS="./sbt +scrooge-publish-local/publishLocal;./sbt ++2.10.7 scrooge-generator/publishLocal;./sbt ++2.12.8 scrooge-generator/publishLocal;./sbt ^^0.13.18 scrooge-sbt-plugin/publishLocal;./sbt \"project scrooge-sbt-plugin\" ^^1.2.8 publishLocal"
+SCROOGE_CORE_COMMANDS="./sbt +scrooge-publish-local/publishLocal;./sbt ++2.11.12 scrooge-generator/publishLocal;./sbt ++2.12.8 scrooge-generator/publishLocal;./sbt ^^1.2.8 scrooge-sbt-plugin/publishLocal"
 
 declare "scroogecore_name=scrooge"
 declare "scroogecore_commands=$SCROOGE_CORE_COMMANDS"

--- a/bin/build
+++ b/bin/build
@@ -14,7 +14,7 @@ UTIL_COMMANDS="./sbt +test:compile +publishLocal; ./sbt ++2.11.12 util-intellij/
 declare "util_name=util"
 declare "util_commands=$UTIL_COMMANDS"
 
-SCROOGE_CORE_COMMANDS="./sbt +scrooge-publish-local/publishLocal;./sbt ++2.10.6 scrooge-generator/publishLocal;./sbt ++2.12.8 scrooge-generator/publishLocal;./sbt ^^0.13.16 scrooge-sbt-plugin/publishLocal;./sbt \"project scrooge-sbt-plugin\" ^^1.2.8 publishLocal"
+SCROOGE_CORE_COMMANDS="./sbt +scrooge-publish-local/publishLocal;./sbt ++2.10.7 scrooge-generator/publishLocal;./sbt ++2.12.8 scrooge-generator/publishLocal;./sbt ^^0.13.18 scrooge-sbt-plugin/publishLocal;./sbt \"project scrooge-sbt-plugin\" ^^1.2.8 publishLocal"
 
 declare "scroogecore_name=scrooge"
 declare "scroogecore_commands=$SCROOGE_CORE_COMMANDS"


### PR DESCRIPTION
Problem

Dodo's build script uses sbt versions that are incompatible with
JDK 11.

Solution

Let's move scala 2.10.6 to 2.10.7 and sbt 0.13.16 to 0.13.18